### PR TITLE
fix: nil-check for VENGEANCE_INVENTORY_FRAGMENT and FURNITURE_VAULT_FRAGMENT on load

### DIFF
--- a/LibFilters-3.0/files/constants.lua
+++ b/LibFilters-3.0/files/constants.lua
@@ -698,7 +698,7 @@ local invVengeance                = kbc.invVengeance
 kbc.vengeanceInvCtrl			  = ZO_VengeanceInventory
 kbc.invVengeanceFragment          = VENGEANCE_INVENTORY_FRAGMENT
 local invVengeanceFragment = kbc.invVengeanceFragment
-kbc.invVengeanceFragment._name = "VENGEANCE_INVENTORY_FRAGMENT"
+if invVengeanceFragment then kbc.invVengeanceFragment._name = "VENGEANCE_INVENTORY_FRAGMENT" end --nil-check: VENGEANCE_INVENTORY_FRAGMENT may not exist yet
 
 
 --[Banks]
@@ -922,7 +922,7 @@ kbc.invFurnitureVaultWithdraw               = inventories[invTypeFurnitureVault]
 local invFurnitureVaultWithdraw 			= kbc.invFurnitureVaultWithdraw
 kbc.furnitureVaultWithdrawFragment       	= FURNITURE_VAULT_FRAGMENT
 local furnitureVaultWithdrawFragment 		= kbc.furnitureVaultWithdrawFragment
-furnitureVaultWithdrawFragment._name = "FURNITURE_VAULT_FRAGMENT"
+if furnitureVaultWithdrawFragment then furnitureVaultWithdrawFragment._name = "FURNITURE_VAULT_FRAGMENT" end --nil-check: FURNITURE_VAULT_FRAGMENT may not exist yet
 kbc.furnitureVaultScene      		  		= getScene(SM, "furnitureVault")
 local furnitureVaultScene 					= kbc.furnitureVaultScene
 


### PR DESCRIPTION
Got a crash after the latest ESO update when opening a vendor window:

```
Inventory.lua:943: attempt to index a nil value
```

Stack trace had `LibFilters3_filterType = 6` inside `ZO_StoreManager`, so LibFilters was active at the time.

Digging through `constants.lua`, I found that `VENGEANCE_INVENTORY_FRAGMENT` (line 701) and `FURNITURE_VAULT_FRAGMENT` (line 925) get `._name` set directly without a nil check. If those globals aren't initialized yet when the addon loads, it would crash constants.lua mid-load and leave LibFilters partially broken.

This PR adds a nil guard before each `._name` assignment.

**Note:** The crash stopped after a full game restart (before I could test with `/reloadui`), so I can't confirm this was the exact cause. But the nil guards seem like a good defensive fix either way.